### PR TITLE
Added tactics bonus directly to skill mods.

### DIFF
--- a/act.c
+++ b/act.c
@@ -53,7 +53,7 @@ static void increase_rage(int cn) {
     int rage_diff;
 
     if (ch[cn].value[1][V_RAGE]) {
-        rage_diff = ((ch[cn].value[0][V_RAGE] + tactics2skill(ch[cn].value[0][V_TACTICS] + 14)) * POWERSCALE - ch[cn].rage);
+        rage_diff = (ch[cn].value[0][V_RAGE] * POWERSCALE - ch[cn].rage);
         ch[cn].rage += rage_diff / 20;
     }
 }

--- a/balance.c
+++ b/balance.c
@@ -48,11 +48,11 @@ double get_spell_average(int cn) {
 }
 
 int tactics2skill(int val) {
-    return val * 0.15;
+    return val * 15 / 100;
 }
 
 int tactics2spell(int val) {
-    return val * 0.15;
+    return val * 15 / 100;
 }
 
 int tactics2melee(int val) {
@@ -60,13 +60,13 @@ int tactics2melee(int val) {
 }
 
 int spellpower(int cn, int v) {
-    return ch[cn].value[0][v] + tactics2spell(ch[cn].value[0][V_TACTICS]);
+    return ch[cn].value[0][v];
 }
 
 int get_parry_skill(int cn) {
     int val;
 
-    if (ch[cn].value[1][V_PARRY]) val = get_fight_skill(cn) + ch[cn].value[0][V_PARRY] * 2 + tactics2melee(ch[cn].value[0][V_TACTICS]);
+    if (ch[cn].value[1][V_PARRY]) val = get_fight_skill(cn) + ch[cn].value[0][V_PARRY] * 2;
     else if (ch[cn].flags & CF_EDEMON) val = get_fight_skill(cn) * 3.5;
     else if (ch[cn].value[1][V_MAGICSHIELD]) val = get_fight_skill(cn) + ch[cn].value[0][V_MAGICSHIELD] * 2 - min(10, ch[cn].level / 2);
     else val = get_fight_skill(cn) + get_spell_average(cn) * 2;
@@ -77,7 +77,7 @@ int get_parry_skill(int cn) {
 int get_attack_skill(int cn) {
     int val;
 
-    if (ch[cn].value[1][V_ATTACK]) val = get_fight_skill(cn) + ch[cn].value[0][V_ATTACK] * 2 + tactics2melee(ch[cn].value[0][V_TACTICS]);
+    if (ch[cn].value[1][V_ATTACK]) val = get_fight_skill(cn) + ch[cn].value[0][V_ATTACK] * 2;
     else if (ch[cn].flags & CF_EDEMON) val = get_fight_skill(cn) * 3.5;
     else {
         val = get_fight_skill(cn) + get_spell_average(cn) * 2 - ch[cn].level * 3 - 20;
@@ -91,8 +91,7 @@ int get_surround_attack_skill(int cn) {
     int val;
 
     if (ch[cn].value[1][V_SURROUND]) val = get_fight_skill(cn) +
-        ch[cn].value[0][V_SURROUND] * 2 +
-        tactics2melee(ch[cn].value[0][V_TACTICS]) - 20;
+        ch[cn].value[0][V_SURROUND] * 2 - 20;
     else return 0;
 
     return val;
@@ -248,7 +247,6 @@ int immunity_reduction(int caster, int subject, int skill_strength) {
     extern int showspell;
 
     immun = ch[subject].value[0][V_IMMUNITY];
-    if (ch[subject].value[1][V_TACTICS]) immun += tactics2skill(ch[subject].value[0][V_TACTICS] + 14);
     if (ch[subject].value[1][V_RAGE]) immun += ch[subject].rage / POWERSCALE / RAGEMOD;
 
     diff = skill_strength - immun;
@@ -268,7 +266,6 @@ int freeze_value(int cn, int co) {
     int str, dam, diff, immun;
 
     immun = ch[co].value[0][V_IMMUNITY];
-    if (ch[co].value[1][V_TACTICS]) immun += tactics2skill(ch[co].value[0][V_TACTICS] + 14);
     if (ch[co].value[1][V_RAGE]) immun += ch[co].rage / POWERSCALE / RAGEMOD;
 
     str = spellpower(cn, V_FREEZE);
@@ -293,7 +290,6 @@ int warcry_value(int cn, int co, int pwr) {
     int str, immun, diff, dam;
 
     immun = ch[co].value[0][V_IMMUNITY];
-    if (ch[co].value[1][V_TACTICS]) immun += tactics2skill(ch[co].value[0][V_TACTICS] + 14);
     if (ch[co].value[1][V_RAGE]) immun += ch[co].rage / POWERSCALE / RAGEMOD;
 
     diff = pwr - immun;

--- a/balance.c
+++ b/balance.c
@@ -51,14 +51,6 @@ int tactics2skill(int val) {
     return val * 15 / 100;
 }
 
-int tactics2spell(int val) {
-    return val * 15 / 100;
-}
-
-int tactics2melee(int val) {
-    return tactics2skill(val) * 3;
-}
-
 int spellpower(int cn, int v) {
     return ch[cn].value[0][v];
 }

--- a/balance.h
+++ b/balance.h
@@ -10,5 +10,4 @@
 #define RAGEMOD 4 // rage skill is divided by this before being used
 
 int skilldiff2percent(int diff);
-int tactics2spell(int val);
 int tactics2skill(int val);

--- a/create.c
+++ b/create.c
@@ -1604,7 +1604,37 @@ void update_char(int cn) {
         else if (n <= V_STR && ch[cn].value[0][n] < 0) ch[cn].value[0][n] = 0;
     }
 
-    if (ch[cn].value[1][V_SPEEDSKILL]) ch[cn].value[0][V_SPEED] += ch[cn].value[0][V_SPEEDSKILL] / 2 + tactics2skill(ch[cn].value[0][V_TACTICS]) / 2;
+	// add tactics bonuses
+	if (ch[cn].value[1][V_TACTICS]) {
+		
+		int skillBonus = tactics2skill(ch[cn].value[0][V_TACTICS]);
+		int spellBonus = tactics2spell(ch[cn].value[0][V_TACTICS]);
+
+		if (ch[cn].value[1][V_DAGGER]) ch[cn].value[0][V_DAGGER] += skillBonus;
+		if (ch[cn].value[1][V_HAND]) ch[cn].value[0][V_HAND] += skillBonus;
+		if (ch[cn].value[1][V_STAFF]) ch[cn].value[0][V_STAFF] += skillBonus;
+		if (ch[cn].value[1][V_SWORD]) ch[cn].value[0][V_SWORD] += skillBonus;
+		if (ch[cn].value[1][V_TWOHAND]) ch[cn].value[0][V_TWOHAND] += skillBonus;
+
+		if (ch[cn].value[1][V_ATTACK]) ch[cn].value[0][V_ATTACK] += skillBonus;
+		if (ch[cn].value[1][V_PARRY]) ch[cn].value[0][V_PARRY] += skillBonus;
+		if (ch[cn].value[1][V_SURROUND]) ch[cn].value[0][V_SURROUND] += skillBonus;
+		if (ch[cn].value[1][V_SPEEDSKILL]) ch[cn].value[0][V_SPEEDSKILL] += skillBonus;
+		if (ch[cn].value[1][V_BARTER]) ch[cn].value[0][V_BARTER] += skillBonus;
+		if (ch[cn].value[1][V_PERCEPT]) ch[cn].value[0][V_PERCEPT] += skillBonus;
+		if (ch[cn].value[1][V_STEALTH]) ch[cn].value[0][V_STEALTH] += skillBonus;
+		if (ch[cn].value[1][V_RAGE]) ch[cn].value[0][V_RAGE] += skillBonus;
+		
+		if (ch[cn].value[1][V_WARCRY]) ch[cn].value[0][V_WARCRY] += spellBonus;
+		if (ch[cn].value[1][V_HEAL]) ch[cn].value[0][V_HEAL] += spellBonus;
+		if (ch[cn].value[1][V_FREEZE]) ch[cn].value[0][V_FREEZE] += spellBonus;
+		if (ch[cn].value[1][V_FLASH]) ch[cn].value[0][V_FLASH] += spellBonus;
+		if (ch[cn].value[1][V_FIRE]) ch[cn].value[0][V_FIRE] += spellBonus;
+		if (ch[cn].value[1][V_IMMUNITY]) ch[cn].value[0][V_IMMUNITY] += spellBonus;
+	}
+		
+
+    if (ch[cn].value[1][V_SPEEDSKILL]) ch[cn].value[0][V_SPEED] += ch[cn].value[0][V_SPEEDSKILL] / 2;
 
     if (ch[cn].x && oldlight != ch[cn].value[0][V_LIGHT]) {
         newlight = ch[cn].value[0][V_LIGHT];

--- a/create.c
+++ b/create.c
@@ -1606,31 +1606,10 @@ void update_char(int cn) {
 
 	// add tactics bonuses
 	if (ch[cn].value[1][V_TACTICS]) {
-		
 		int skill_bonus = tactics2skill(ch[cn].value[0][V_TACTICS]);
-		int spell_bonus = tactics2spell(ch[cn].value[0][V_TACTICS]);
-
-		if (ch[cn].value[1][V_DAGGER]) ch[cn].value[0][V_DAGGER] += skillBonus;
-		if (ch[cn].value[1][V_HAND]) ch[cn].value[0][V_HAND] += skillBonus;
-		if (ch[cn].value[1][V_STAFF]) ch[cn].value[0][V_STAFF] += skillBonus;
-		if (ch[cn].value[1][V_SWORD]) ch[cn].value[0][V_SWORD] += skillBonus;
-		if (ch[cn].value[1][V_TWOHAND]) ch[cn].value[0][V_TWOHAND] += skillBonus;
-
-		if (ch[cn].value[1][V_ATTACK]) ch[cn].value[0][V_ATTACK] += skillBonus;
-		if (ch[cn].value[1][V_PARRY]) ch[cn].value[0][V_PARRY] += skillBonus;
-		if (ch[cn].value[1][V_SURROUND]) ch[cn].value[0][V_SURROUND] += skillBonus;
-		if (ch[cn].value[1][V_SPEEDSKILL]) ch[cn].value[0][V_SPEEDSKILL] += skillBonus;
-		if (ch[cn].value[1][V_BARTER]) ch[cn].value[0][V_BARTER] += skillBonus;
-		if (ch[cn].value[1][V_PERCEPT]) ch[cn].value[0][V_PERCEPT] += skillBonus;
-		if (ch[cn].value[1][V_STEALTH]) ch[cn].value[0][V_STEALTH] += skillBonus;
-		if (ch[cn].value[1][V_RAGE]) ch[cn].value[0][V_RAGE] += skillBonus;
-		
-		if (ch[cn].value[1][V_WARCRY]) ch[cn].value[0][V_WARCRY] += spellBonus;
-		if (ch[cn].value[1][V_HEAL]) ch[cn].value[0][V_HEAL] += spellBonus;
-		if (ch[cn].value[1][V_FREEZE]) ch[cn].value[0][V_FREEZE] += spellBonus;
-		if (ch[cn].value[1][V_FLASH]) ch[cn].value[0][V_FLASH] += spellBonus;
-		if (ch[cn].value[1][V_FIRE]) ch[cn].value[0][V_FIRE] += spellBonus;
-		if (ch[cn].value[1][V_IMMUNITY]) ch[cn].value[0][V_IMMUNITY] += spellBonus;
+		for (n = V_DAGGER; n < V_DEMON; n++) {
+			if (n != V_TACTICS && n != V_BLESS && n != V_MAGICSHIELD && ch[cn].value[1][n]) ch[cn].value[0][n] += skill_bonus;
+		}
 	}
 		
 

--- a/create.c
+++ b/create.c
@@ -1607,8 +1607,8 @@ void update_char(int cn) {
 	// add tactics bonuses
 	if (ch[cn].value[1][V_TACTICS]) {
 		
-		int skillBonus = tactics2skill(ch[cn].value[0][V_TACTICS]);
-		int spellBonus = tactics2spell(ch[cn].value[0][V_TACTICS]);
+		int skill_bonus = tactics2skill(ch[cn].value[0][V_TACTICS]);
+		int spell_bonus = tactics2spell(ch[cn].value[0][V_TACTICS]);
 
 		if (ch[cn].value[1][V_DAGGER]) ch[cn].value[0][V_DAGGER] += skillBonus;
 		if (ch[cn].value[1][V_HAND]) ch[cn].value[0][V_HAND] += skillBonus;

--- a/escape.c
+++ b/escape.c
@@ -53,10 +53,10 @@ int char_can_flee(int cn) {
     if (ch[cn].escape_timer >= ticker) return 0;
 
     for (m = 0; m < 4; m++)
-        if ((co = ch[cn].enemy[m]) != 0) per += ch[co].value[0][V_PERCEPT] + tactics2skill(ch[co].value[0][V_TACTICS] + 14);
+        if ((co = ch[cn].enemy[m]) != 0) per += ch[co].value[0][V_PERCEPT];
 
-    if (has_spell(cn, IDR_WARCRY) || has_spell(cn, IDR_FREEZE)) ste = (ch[cn].value[0][V_STEALTH] + tactics2skill(ch[co].value[0][V_TACTICS] + 14)) / 2;
-    else ste = ch[cn].value[0][V_STEALTH] + tactics2skill(ch[co].value[0][V_TACTICS] + 14);
+    if (has_spell(cn, IDR_WARCRY) || has_spell(cn, IDR_FREEZE)) ste = (ch[cn].value[0][V_STEALTH]) / 2;
+    else ste = ch[cn].value[0][V_STEALTH];
     ;
 
     chance = ste * 10 / per;

--- a/see.c
+++ b/see.c
@@ -51,14 +51,14 @@ int char_see_char_nolos(int cn, int co) {
 
     light = max(32 - light, 0) * 2;
 
-    if (ch[co].speed_mode == SM_STEALTH) stealth = ch[co].value[0][V_STEALTH] + tactics2skill(ch[co].value[0][V_TACTICS]);
+    if (ch[co].speed_mode == SM_STEALTH) stealth = ch[co].value[0][V_STEALTH];
     else stealth = 0;
 
     // 0...64        4..400
     if (stealth) vco = light + stealth + dist;
     else vco = 0;
 
-    vcn = ch[cn].value[0][V_PERCEPT] + tactics2skill(ch[cn].value[0][V_TACTICS]) + 16 + 49;
+    vcn = ch[cn].value[0][V_PERCEPT] + 16 + 49;
 
     if (vcn >= vco) return 1;
 

--- a/store.c
+++ b/store.c
@@ -68,7 +68,7 @@ int salesprice(int cn, int co, int nr) {
     if (store[s]->ware[nr].cnt) {
         price = store[s]->ware[nr].item.value;
 
-        skill = ch[co].value[0][V_BARTER] + tactics2skill(ch[co].value[0][V_TACTICS]) + get_support_prof(co, P_TRADER) * 5 + clan_trade_bonus(co);
+        skill = ch[co].value[0][V_BARTER] + get_support_prof(co, P_TRADER) * 5 + clan_trade_bonus(co);
 
         mult = 1.55 - (skill / 1000.0);
         if (mult < 1.05) mult = 1.05;
@@ -92,7 +92,7 @@ int buyprice(int cn, int in) {
     price = it[in].value;
 
     if (!(it[in].flags & IF_MONEY)) {
-        skill = ch[cn].value[0][V_BARTER] + tactics2skill(ch[cn].value[0][V_TACTICS]) + get_support_prof(cn, P_TRADER) * 5 + clan_trade_bonus(cn);
+        skill = ch[cn].value[0][V_BARTER] + get_support_prof(cn, P_TRADER) * 5 + clan_trade_bonus(cn);
 
         mult = 0.75 + (skill / 2500.0);
         if (mult > 0.95) mult = 0.95;


### PR DESCRIPTION
Added tactics bonus directly to the mods of the following skills: V_DAGGER
V_HAND
V_STAFF
V_SWORD
V_TWOHAND

V_ATTACK
V_PARRY
V_SURROUND
V_SPEEDSKILL
V_BARTER
V_PERCEPT
V_STEALTH
V_RAGE
V_WARCRY
V_HEAL
V_FREEZE
V_FLASH
V_FIRE
V_IMMUNITY

Removed the +14 to tactics in the Immunity and Rage calculations and in the Stealth/Perception flee chance calculations.

Modified the tactics formula to correctly apply every 3rd bonus at every 20 tactics.

Removed tactics calculations from other parts of the code.