### PR TITLE
Add Docker support for easy server deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git
+.gitignore
+
+# Build artifacts (we build fresh in container)
+*.o
+server35
+chatserver
+create_account
+create_character
+create_weapons
+create_armor
+
+# Runtime generated
+runtime/
+logs/
+*.log
+
+# Documentation
+*.md
+!readme.md
+
+# Editor files
+*.swp
+*.swo
+*~
+
+# Docker compose files
+docker-compose*.yml
+
+# Misc
+MYSQLPASSWD
+accman/

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,262 @@
+# Astonia 3.5 Community Server - Docker Deployment
+
+## Image Variants
+
+| Tag | Size | Description |
+|-----|------|-------------|
+| `astoniacommunity/astonia_server_35:latest` | ~296MB | Includes default zones - ready to play |
+| `astoniacommunity/astonia_server_35:base` | ~180MB | No zones - for custom zone development |
+| `astoniacommunity/astonia_server_35:builder` | ~649MB | Build environment - for code customization |
+
+## Quick Start
+
+### Using Docker Compose (Recommended)
+
+```bash
+# Clone the repository
+git clone https://github.com/AstoniaCommunity/astonia_community_server35
+cd astonia_community_server35
+
+# Start the server (builds image if needed)
+docker compose up -d
+
+# View logs
+docker compose logs -f server
+
+# Create an account and character
+docker exec astonia-server /entrypoint.sh create_account your@email.com yourpassword
+docker exec astonia-server /entrypoint.sh create_character 1 YourCharName MWG
+```
+
+### Using Pre-built Image
+
+```bash
+# Create a docker-compose.yml:
+cat > docker-compose.yml << 'EOF'
+version: '3.8'
+
+services:
+  db:
+    image: mariadb:10.11
+    container_name: astonia-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: astonia
+      MYSQL_DATABASE: merc35
+    volumes:
+      - astonia-db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  server:
+    image: astoniacommunity/astonia_server_35:latest
+    container_name: astonia-server
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      AS35_DBHOST: db
+      AS35_DBUSER: root
+      AS35_DBPASS: astonia
+      AS35_DBNAME: merc35
+    ports:
+      - "8080-8090:8080-8090"
+      - "27584-27620:27584-27620"
+
+volumes:
+  astonia-db-data:
+EOF
+
+# Start
+docker compose up -d
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AS35_DBHOST` | `db` | MySQL/MariaDB hostname |
+| `AS35_DBUSER` | `root` | Database username |
+| `AS35_DBPASS` | `astonia` | Database password |
+| `AS35_DBNAME` | `merc35` | Database name |
+| `AS35_CHATHOST` | `localhost` | Chat server hostname |
+
+### Ports
+
+| Port Range | Description |
+|------------|-------------|
+| `8080-8090` | Game area servers |
+| `27584-27620` | Additional game area servers |
+| `5554` | Chat server (internal, not exposed by default) |
+
+## Commands
+
+```bash
+# Start server
+docker compose up -d
+
+# Stop server
+docker compose down
+
+# View logs
+docker compose logs -f server
+
+# Create account
+docker exec astonia-server /entrypoint.sh create_account <email> <password>
+
+# Create character
+# Classes: MWG = Mage/Warrior/God hybrid
+docker exec astonia-server /entrypoint.sh create_character <account_id> <name> <class>
+
+# Access shell
+docker exec -it astonia-server bash
+
+# Reinitialize database (WARNING: destroys data)
+docker compose down -v
+docker compose up -d
+```
+
+## Connecting with a Client
+
+Use the Astonia client (moac) to connect:
+
+```bash
+bin/moac -u<CharacterName> -p<password> -d<server_ip> -v35
+```
+
+## Architecture
+
+The Docker container runs multiple processes:
+- 1x `chatserver` - Handles in-game chat
+- ~30x `server35` - One per game area/zone
+
+All processes are managed by the entrypoint script and will be gracefully 
+shutdown when the container stops.
+
+## Code Customization (Builder Image)
+
+For modifying the server code without setting up a local build environment:
+
+```bash
+# Pull the builder image
+docker pull astoniacommunity/astonia_server_35:builder
+
+# Run interactively with your modified source mounted
+docker run -it --rm \
+  -v $(pwd):/build \
+  astoniacommunity/astonia_server_35:builder
+
+# Inside the container:
+make clean && make -j$(nproc)
+
+# The compiled binaries are now in your local directory
+```
+
+### Building a Custom Image
+
+Create a simple Dockerfile that uses the builder:
+
+```dockerfile
+# Build custom server
+FROM astoniacommunity/astonia_server_35:builder AS builder
+WORKDIR /build
+# Source is already there, or mount/copy your modified version
+RUN make clean && make -j$(nproc)
+
+# Create runtime image
+FROM astoniacommunity/astonia_server_35:base
+COPY --from=builder /build/server35 /server/
+COPY --from=builder /build/chatserver /server/
+COPY --from=builder /build/runtime/ /server/runtime/
+# Add your custom zones
+COPY ./my-zones/ /server/zones/
+```
+
+Build and run:
+```bash
+docker build -t my-custom-astonia .
+docker compose up -d  # with your custom image
+```
+
+## Custom Zone Development
+
+For custom zone development, use the `base` image and mount your zones:
+
+```yaml
+# docker-compose.yml for custom zones
+version: '3.8'
+
+services:
+  db:
+    image: mariadb:10.11
+    environment:
+      MYSQL_ROOT_PASSWORD: astonia
+      MYSQL_DATABASE: merc35
+    volumes:
+      - astonia-db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  server:
+    image: astoniacommunity/astonia_server_35:base
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      AS35_DBHOST: db
+      AS35_DBUSER: root
+      AS35_DBPASS: astonia
+      AS35_DBNAME: merc35
+    ports:
+      - "8080-8090:8080-8090"
+      - "27584-27620:27584-27620"
+    volumes:
+      # Mount your custom zones folder
+      - ./my-zones:/server/zones
+
+volumes:
+  astonia-db-data:
+```
+
+Your `my-zones` folder should have the same structure as the default zones:
+```
+my-zones/
+  generic/
+    weapons.itm  (generated, copy from default)
+    armor.itm    (generated, copy from default)
+    *.itm, *.map, etc.
+  1/
+  2/
+  ...
+  37/
+```
+
+## Building Locally
+
+```bash
+# Build all variants
+docker build -t astonia35:latest .                           # With zones (default)
+docker build -t astonia35:base --target runtime-base .       # Without zones
+docker build -t astonia35:builder --target builder .         # Build environment
+
+# Or with docker compose
+docker compose build
+```
+
+## Security Notes
+
+- Change the default database password in production
+- Configure a firewall to restrict access to game ports
+- The chat server port (5554) should not be exposed publicly
+- Consider running behind a reverse proxy for additional security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,141 @@
+# Astonia 3.5 Community Server - Multi-target Dockerfile
+#
+# Available targets:
+#   builder           - Build environment for code customization
+#   runtime-base      - Server without zones (for custom zones)
+#   runtime-with-zones - Server with default zones (default)
+#
+# Image tags on DockerHub:
+#   astoniacommunity/astonia_server_35:latest  - Ready to play
+#   astoniacommunity/astonia_server_35:base    - For custom zones
+#   astoniacommunity/astonia_server_35:builder - For code customization
+#
+# Examples:
+#   docker build -t astonia:latest .
+#   docker build -t astonia:base --target runtime-base .
+#   docker build -t astonia:builder --target builder .
+#
+# ============================================================================
+# Stage 1: Builder - Build environment with all dependencies
+# ============================================================================
+FROM ubuntu:22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Add i386 architecture and install build dependencies
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y \
+        gcc-multilib \
+        make \
+        lib32z-dev \
+        libargon2-dev:i386 \
+        libmysqlclient-dev:i386 \
+        # Useful tools for development
+        git \
+        vim \
+        less \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy source files
+COPY *.c *.h *.S Makefile ./
+COPY .obj/ .obj/
+COPY zones/ zones/
+
+# Create runtime directories that the Makefile expects
+RUN mkdir -p runtime/generic runtime/1 runtime/2 runtime/3 runtime/5 \
+    runtime/6 runtime/8 runtime/10 runtime/11 runtime/14 runtime/15 \
+    runtime/16 runtime/17 runtime/18 runtime/19 runtime/22 runtime/23 \
+    runtime/24 runtime/25 runtime/26 runtime/27 runtime/28 runtime/29 \
+    runtime/31 runtime/33 runtime/36 runtime/37
+
+# Build the server
+RUN make -j$(nproc)
+
+# For the builder image, we want a clean state for rebuilding
+# Create a script to help users build
+RUN echo '#!/bin/bash\n\
+echo "Astonia 3.5 Build Environment"\n\
+echo "=============================="\n\
+echo ""\n\
+echo "To build:"\n\
+echo "  make clean && make -j$(nproc)"\n\
+echo ""\n\
+echo "To copy built files out:"\n\
+echo "  # From host: docker cp <container>:/build/server35 ."\n\
+echo ""\n\
+echo "Source files are in /build"\n\
+exec "$@"' > /entrypoint-builder.sh && chmod +x /entrypoint-builder.sh
+
+ENTRYPOINT ["/entrypoint-builder.sh"]
+CMD ["/bin/bash"]
+
+# ============================================================================
+# Stage 2: Runtime Base - Server without zones (for custom zone development)
+# ============================================================================
+FROM ubuntu:22.04 AS runtime-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Add i386 architecture and install runtime dependencies
+RUN dpkg --add-architecture i386 && \
+    apt-get update && \
+    apt-get install -y \
+        libc6:i386 \
+        libz1:i386 \
+        libargon2-1:i386 \
+        libmysqlclient21:i386 \
+        libstdc++6:i386 \
+        libgcc-s1:i386 \
+        mysql-client \
+        procps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /server
+
+# Copy built binaries from builder
+COPY --from=builder /build/server35 .
+COPY --from=builder /build/chatserver .
+COPY --from=builder /build/create_account .
+COPY --from=builder /build/create_character .
+
+# Copy runtime directory (compiled DLLs for each area)
+COPY --from=builder /build/runtime/ runtime/
+
+# Create empty zones directory structure (user must mount their own)
+RUN mkdir -p zones/generic zones/presets && \
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 22 23 24 25 26 28 29 30 33 36 37; do \
+        mkdir -p zones/$i; \
+    done
+
+# Copy generated item files (these are needed regardless)
+COPY --from=builder /build/zones/generic/weapons.itm zones/generic/
+COPY --from=builder /build/zones/generic/armor.itm zones/generic/
+
+# Copy SQL files for database initialization
+COPY create_tables.sql merc.sql ./
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Create motd.txt
+RUN echo "Welcome to Astonia Community Server" > motd.txt
+
+# Expose ports
+EXPOSE 5554
+EXPOSE 8080-8090
+EXPOSE 27584-27777
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["start"]
+
+# ============================================================================
+# Stage 3: Runtime with Zones - Ready to play (default)
+# ============================================================================
+FROM runtime-base AS runtime-with-zones
+
+# Copy all zone data from builder (overwrites empty structure)
+COPY --from=builder /build/zones/ zones/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  db:
+    image: mariadb:10.11
+    container_name: astonia-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-astonia}
+      MYSQL_DATABASE: merc35
+    volumes:
+      - astonia-db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - astonia-net
+
+  server:
+    image: ${DOCKER_IMAGE:-astoniacommunity/astonia_server_35:latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: astonia-server
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      AS35_DBHOST: db
+      AS35_DBUSER: root
+      AS35_DBPASS: ${MYSQL_ROOT_PASSWORD:-astonia}
+      AS35_DBNAME: merc35
+      AS35_CHATHOST: localhost
+    ports:
+      # Chat server (internal communication, usually not exposed publicly)
+      # - "5554:5554"
+      # Game server ports - area servers
+      - "8080-8090:8080-8090"
+      - "27584-27620:27584-27620"
+    volumes:
+      # Persist server logs (optional)
+      - ./logs:/server/logs
+    networks:
+      - astonia-net
+
+volumes:
+  astonia-db-data:
+
+networks:
+  astonia-net:
+    driver: bridge

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+set -e
+
+# Function to gracefully stop all server processes
+cleanup() {
+    echo "Shutting down Astonia server..."
+    pkill -TERM chatserver 2>/dev/null || true
+    pkill -TERM server35 2>/dev/null || true
+    sleep 2
+    pkill -KILL chatserver 2>/dev/null || true
+    pkill -KILL server35 2>/dev/null || true
+    echo "Shutdown complete."
+    exit 0
+}
+
+# Trap signals for graceful shutdown
+trap cleanup SIGTERM SIGINT SIGQUIT
+
+# Export environment variables for the server and tools
+export AS35_DBHOST="${AS35_DBHOST:-db}"
+export AS35_DBUSER="${AS35_DBUSER:-root}"
+export AS35_DBPASS="${AS35_DBPASS:-astonia}"
+export AS35_DBNAME="${AS35_DBNAME:-merc35}"
+export AS35_CHATHOST="${AS35_CHATHOST:-localhost}"
+
+# Wait for MySQL to be ready
+wait_for_mysql() {
+    echo "Waiting for MySQL at ${AS35_DBHOST}..."
+    local max_tries=60
+    local count=0
+    
+    while [ $count -lt $max_tries ]; do
+        if mysql -h "${AS35_DBHOST}" \
+                 -u "${AS35_DBUSER}" -p"${AS35_DBPASS}" \
+                 -e "SELECT 1" >/dev/null 2>&1; then
+            echo "MySQL is ready!"
+            return 0
+        fi
+        count=$((count + 1))
+        echo "MySQL not ready yet... ($count/$max_tries)"
+        sleep 2
+    done
+    
+    echo "ERROR: MySQL did not become ready in time"
+    return 1
+}
+
+# Initialize database if needed
+init_database() {
+    echo "Checking database..."
+    
+    # Check if database exists and has tables
+    local tables=$(mysql -h "${AS35_DBHOST}" \
+                        -u "${AS35_DBUSER}" -p"${AS35_DBPASS}" \
+                        -N -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='${AS35_DBNAME}'" 2>/dev/null || echo "0")
+    
+    if [ "$tables" = "0" ] || [ -z "$tables" ]; then
+        echo "Initializing database..."
+        mysql -h "${AS35_DBHOST}" \
+              -u "${AS35_DBUSER}" -p"${AS35_DBPASS}" \
+              < create_tables.sql
+        mysql -h "${AS35_DBHOST}" \
+              -u "${AS35_DBUSER}" -p"${AS35_DBPASS}" \
+              "${AS35_DBNAME}" < merc.sql
+        echo "Database initialized."
+    else
+        echo "Database already initialized ($tables tables found)."
+    fi
+}
+
+# Start the server processes
+start_server() {
+    echo "Starting Astonia Community Server..."
+    
+    # Start chatserver first
+    echo "Starting chatserver..."
+    ./chatserver &
+    sleep 1
+    
+    # Define areas to start
+    AREAS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 22 23 24 25 26 28 29 30 33 36 37"
+    
+    # Start all area servers (no -d flag, run in background with &)
+    for area in $AREAS; do
+        echo "Starting area $area..."
+        ./server35 -a $area -e &
+        sleep 0.5
+    done
+    
+    echo "All server processes started!"
+    echo "Server is ready for connections."
+    
+    # Keep the container running and wait for any process to exit
+    while true; do
+        # Check if critical processes are still running
+        if ! pgrep -x chatserver > /dev/null; then
+            echo "WARNING: chatserver died, restarting..."
+            ./chatserver &
+        fi
+        
+        # Count running server35 processes
+        local running
+        running=$(pgrep -c server35 2>/dev/null) || running=0
+        if [ "$running" -lt 5 ]; then
+            echo "WARNING: Only $running server35 processes running. Something may be wrong."
+        fi
+        
+        sleep 10
+    done
+}
+
+# Create an account (for admin use)
+create_account() {
+    if [ -z "$2" ] || [ -z "$3" ]; then
+        echo "Usage: create_account <email> <password>"
+        exit 1
+    fi
+    ./create_account -e "$2" "$3"
+}
+
+# Create a character (for admin use)
+create_character() {
+    if [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
+        echo "Usage: create_character <account_id> <name> <class>"
+        echo "Classes: MWG (Mage Warrior God), etc."
+        exit 1
+    fi
+    ./create_character -e "$2" "$3" "$4"
+}
+
+# Main command handler
+case "${1:-start}" in
+    start)
+        wait_for_mysql
+        init_database
+        start_server
+        ;;
+    create_account)
+        create_account "$@"
+        ;;
+    create_character)
+        create_character "$@"
+        ;;
+    init-db)
+        wait_for_mysql
+        init_database
+        echo "Database initialization complete."
+        ;;
+    bash|sh)
+        exec /bin/bash
+        ;;
+    *)
+        echo "Unknown command: $1"
+        echo "Available commands: start, create_account, create_character, init-db, bash"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds Docker support for easy one-command deployment.

## Quick Start

```bash
docker compose up -d
docker exec astonia-server /entrypoint.sh create_account your@email.com password
docker exec astonia-server /entrypoint.sh create_character 1 YourName MWG
```

## Files Added

| File | Description |
|------|-------------|
| `Dockerfile` | Multi-stage build (builder, base, latest) |
| `docker-compose.yml` | Complete stack with MariaDB |
| `docker-entrypoint.sh` | Manages 30 server processes |
| `DOCKER.md` | Documentation |
| `.dockerignore` | Clean build context |

## DockerHub

- `astoniacommunity/astonia_server_35:latest` - Ready to play
- `astoniacommunity/astonia_server_35:base` - For custom zones
- `astoniacommunity/astonia_server_35:builder` - For code changes

Uses upstream config.c with `-e` flag for AS35_* environment variables.