### PR TITLE
Add /killbless, /killpotion and /noflask commands

### DIFF
--- a/src/alchemy.c
+++ b/src/alchemy.c
@@ -812,6 +812,7 @@ void flask_driver(int in, int cn) {
             if (!mixer_use(cn, in)) return;
             if (ch[cn].flags & CF_NOFLASK) {
                 remove_item_char(in);
+                free_item(in);
                 return;
             }
             strcpy(it[in].name, "Empty Potion");

--- a/src/alchemy.c
+++ b/src/alchemy.c
@@ -754,7 +754,7 @@ int mixer_use(int cn, int in) {
     }
 
     if (!(fre = may_add_spell(cn, IDR_POTION_SP))) {
-        log_char(cn, LOG_SYSTEM, 0, "Another potion is still active.");
+        log_char(cn, LOG_SYSTEM, 0, "Another potion is still active. Use /killpotion to remove it.");
         return 0;
     }
 

--- a/src/alchemy.c
+++ b/src/alchemy.c
@@ -810,6 +810,10 @@ void flask_driver(int in, int cn) {
     if (!(in2 = ch[cn].citem)) {
         if (shaken) { // potion is ready
             if (!mixer_use(cn, in)) return;
+            if (ch[cn].flags & CF_NOFLASK) {
+                remove_item_char(in);
+                return;
+            }
             strcpy(it[in].name, "Empty Potion");
             switch (size) {
             case 1:

--- a/src/base.c
+++ b/src/base.c
@@ -443,7 +443,7 @@ void potion_driver(int in, int cn) {
                  it[in].drdata[3] * POWERSCALE,
                  it[in].drdata[2] * POWERSCALE);
 
-    if (empty) replace_item_char(in, in2);
+    if (empty && (!(ch[cn].flags & CF_NOFLASK))) replace_item_char(in, in2);
     else remove_item_char(in);
 
     free_item(in);

--- a/src/command.c
+++ b/src/command.c
@@ -2382,7 +2382,7 @@ int command(int cn, char *ptr) // 1=ok, 0=repeat
                 return 1;
             }
         }
-        log_char(cn, LOG_SYSTEM, 0, "No Bless found.");
+        log_char(cn, LOG_SYSTEM, 0, "No stat potion found.");
         return 1;
     }
 
@@ -2391,6 +2391,7 @@ int command(int cn, char *ptr) // 1=ok, 0=repeat
         log_char(cn, LOG_SYSTEM, 0, "NoFlask %s.", (ch[cn].flags & CF_NOFLASK) ? "enabled" : "disabled");
         return 1;
     }
+    
     if (cmdcmp(ptr, "status", 0)) {
         struct depot_ppd *depot_ppd;
 

--- a/src/command.c
+++ b/src/command.c
@@ -937,14 +937,17 @@ static void cmd_help(int cn) {
     log_char(cn, LOG_SYSTEM, 0, "/emote <text> - express yourself (also /me, /wave, /bow, /eg)");
     log_char(cn, LOG_SYSTEM, 0, "/gold <amount> - move gold to cursor");
     log_char(cn, LOG_SYSTEM, 0, "/holler <text> - like say, but with vastly increased range");
-    log_char(cn, LOG_SYSTEM, 0, "/hints <cmd> - turn the tutorial 'off', 'on' or 'reset' it.");
+    log_char(cn, LOG_SYSTEM, 0, "/hints <cmd> - turn the tutorial 'off', 'on' or 'reset' it");
     log_char(cn, LOG_SYSTEM, 0, "/ignore <name> - ignore a player in chat and tells");
     log_char(cn, LOG_SYSTEM, 0, "/join <nr> - joins chat channel <nr>");
+    log_char(cn, LOG_SYSTEM, 0, "/killbless - removes bless");
+    log_char(cn, LOG_SYSTEM, 0, "/killpotion - removes stat potion");
     log_char(cn, LOG_SYSTEM, 0, "/lastseen <player> - last time player logged into the game");
     log_char(cn, LOG_SYSTEM, 0, "/leave <nr> - leaves chat channel <nr>");
     log_char(cn, LOG_SYSTEM, 0, "/logout - logout when on blue square");
     log_char(cn, LOG_SYSTEM, 0, "/maxlag <seconds> - set delay for lag control");
     log_char(cn, LOG_SYSTEM, 0, "/murmur <text> - like say, but only within close range");
+    log_char(cn, LOG_SYSTEM, 0, "/noflask - prevents empty flasks when using potions");
     log_char(cn, LOG_SYSTEM, 0, "/notells - do not receive any tells (toggle)");
     log_char(cn, LOG_SYSTEM, 0, "/relation <nr> - show clan <nr>'s relations");
     log_char(cn, LOG_SYSTEM, 0, "/say <text> - makes your character say <text>");
@@ -2351,6 +2354,43 @@ int command(int cn, char *ptr) // 1=ok, 0=repeat
         return 1;
     }
 
+    if (cmdcmp(ptr, "killbless", 5)) {
+        int n, in;
+        for (n = 12; n < 30; n++) {
+            if ((in = ch[cn].item[n]) && it[in].driver == IDR_BLESS) {
+                destroy_effect_type(cn, EF_BLESS);
+                destroy_item(in);
+                ch[cn].item[n] = 0;
+                update_char(cn);
+                log_char(cn, LOG_SYSTEM, 0, "Done.");
+                return 1;
+            }
+        }
+        log_char(cn, LOG_SYSTEM, 0, "No Bless found.");
+        return 1;
+    }
+
+    if (cmdcmp(ptr, "killpotion", 5)) {
+        int n, in;
+        for (n = 12; n < 30; n++) {
+            if ((in = ch[cn].item[n]) && it[in].driver == IDR_POTION_SP) {
+                destroy_effect_type(cn, EF_POTION);
+                destroy_item(in);
+                ch[cn].item[n] = 0;
+                update_char(cn);
+                log_char(cn, LOG_SYSTEM, 0, "Done.");
+                return 1;
+            }
+        }
+        log_char(cn, LOG_SYSTEM, 0, "No Bless found.");
+        return 1;
+    }
+
+    if (cmdcmp(ptr, "noflask", 7)) {
+        ch[cn].flags ^= CF_NOFLASK;
+        log_char(cn, LOG_SYSTEM, 0, "NoFlask %s.", (ch[cn].flags & CF_NOFLASK) ? "enabled" : "disabled");
+        return 1;
+    }
     if (cmdcmp(ptr, "status", 0)) {
         struct depot_ppd *depot_ppd;
 

--- a/src/command.c
+++ b/src/command.c
@@ -2391,7 +2391,7 @@ int command(int cn, char *ptr) // 1=ok, 0=repeat
         log_char(cn, LOG_SYSTEM, 0, "NoFlask %s.", (ch[cn].flags & CF_NOFLASK) ? "enabled" : "disabled");
         return 1;
     }
-    
+
     if (cmdcmp(ptr, "status", 0)) {
         struct depot_ppd *depot_ppd;
 

--- a/src/create.c
+++ b/src/create.c
@@ -417,7 +417,9 @@ static char *CF_tab[] = {
     "CF_SMALLUPDATE", //43
     "CF_NOWHO", //44
     "CF_WON", //45
-    "CF_NOMOVE" //46
+    "CF_NOMOVE", //46
+    "CF_TUTOR", //47
+    "CF_NOFLASK" //48
 };
 
 static int lookup_CF(char *name) {

--- a/src/server.h
+++ b/src/server.h
@@ -260,6 +260,7 @@ extern struct item *it;
 #define CF_WON (1ull << 45) // character won the game (ie killed islena)
 #define CF_NOMOVE (1ull << 46) // fightback doesn't move the player
 #define CF_TUTOR (1ull << 47) // member of the tutor group
+#define CF_NOFLASK (1ull << 48) // stops empty potions replacing used potions
 
 // VALUES
 #define V_HP 0


### PR DESCRIPTION
/killbless (/killb) removes any Bless spells on the pc /killpotion (/killp) removes any stat potion spells from the pc /noflask prevents the creation of empty flasks when using health/mana/combo or stat potions.

Added CF_TUTOR to CF_Tab in create.c for parity with server.h